### PR TITLE
Add ARIA attributes to mobile navigation menu

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,9 +117,11 @@ export default function Home() {
               </li>
             ))}
           </ul>
-          <button 
-            className="md:hidden text-forest" 
+          <button
+            className="md:hidden text-forest"
             aria-label="Menu"
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu"
             onClick={toggleMobileMenu}
           >
             {isMobileMenuOpen ? '✕' : '☰'}
@@ -127,11 +129,11 @@ export default function Home() {
         </nav>
         {/* Mobile Menu */}
         {isMobileMenuOpen && (
-          <div className="md:hidden bg-cream border-t border-sand">
+          <div id="mobile-menu" className="md:hidden bg-cream border-t border-sand">
             <ul className="flex flex-col p-4 space-y-4">
               {navItems.map((item) => (
                 <li key={item.href}>
-                  <a 
+                  <a
                     href={item.href} 
                     className="text-charcoal hover:text-lake block py-2"
                     onClick={() => setIsMobileMenuOpen(false)}


### PR DESCRIPTION
## Summary
- add ARIA attributes to the mobile menu toggle button for accessibility
- assign an id to the mobile menu container to link it with the toggle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8cb409f40832cbc175c9d8b1bf1ef