### PR TITLE
Handle contact form non-OK responses gracefully

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,6 +88,11 @@ export default function Home() {
         body: formData,
       });
 
+      if (!response.ok) {
+        setFormStatus({ type: 'error', message: 'Something went wrong. Please try again.' });
+        return;
+      }
+
       const result = await response.json();
 
       if (result.success) {


### PR DESCRIPTION
## Summary
- stop parsing JSON for non-OK responses from the contact form submission
- surface an error status immediately when the server returns a non-success HTTP code

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8cb433a98832c8f4a968a9cf312e4