### PR TITLE
Update Button component children typing

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,8 +1,9 @@
+import { type ReactNode } from 'react';
 import Link from 'next/link';
 
 interface ButtonProps {
   href: string;
-  children: React.ReactNode;
+  children: ReactNode;
   variant?: 'primary' | 'secondary';
   className?: string;
 }


### PR DESCRIPTION
## Summary
- import the `ReactNode` type in the Button component
- type the `children` prop directly as `ReactNode`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d21a9828832c87984fe73f092121