### PR TITLE
Add ids to testimonials and use stable keys

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,9 +127,12 @@ const comparisonTable = [
 ];
 
 const testimonials = [
-  { quote: '“Julia keeps our rental booked and stress-free. Best decision we made.”' },
-  { quote: '“Professional, responsive, and worth every penny.”' },
-  { quote: '“Our cabin stays booked and stress-free.”' },
+  {
+    id: 'testimonial-1',
+    quote: '“Julia keeps our rental booked and stress-free. Best decision we made.”',
+  },
+  { id: 'testimonial-2', quote: '“Professional, responsive, and worth every penny.”' },
+  { id: 'testimonial-3', quote: '“Our cabin stays booked and stress-free.”' },
 ];
 
 export default function Home() {

--- a/components/TestimonialsSection.tsx
+++ b/components/TestimonialsSection.tsx
@@ -1,4 +1,5 @@
 interface Testimonial {
+  id: string;
   quote: string;
 }
 
@@ -12,8 +13,8 @@ export default function TestimonialsSection({ testimonials }: TestimonialsSectio
       <div className="max-w-6xl mx-auto px-4">
         <h2 className="text-3xl font-bold text-forest text-center mb-10">Testimonials</h2>
         <div className="grid gap-8 md:grid-cols-3">
-          {testimonials.map((testimonial, index) => (
-            <blockquote key={index} className="bg-white p-6 rounded shadow">
+          {testimonials.map((testimonial) => (
+            <blockquote key={testimonial.id} className="bg-white p-6 rounded shadow">
               <p className="text-slate mb-2">{testimonial.quote}</p>
               <div>⭐️⭐️⭐️⭐️⭐️</div>
             </blockquote>


### PR DESCRIPTION
## Summary
- add unique identifiers to each testimonial entry
- update the testimonials section to use the new ids as stable React keys

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8d2240e94832c96dc1276cced9e4d