### PR TITLE
Add responsive sizes to hero and property images

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -9,6 +9,7 @@ export default function HeroSection() {
           src="https://images.unsplash.com/photo-1506905925346-14b4e5b4e4c3?auto=format&fit=crop&w=1920&q=80"
           alt="Pacific Northwest mountain landscape"
           fill
+          sizes="100vw"
           className="object-cover scale-105"
           priority
         />

--- a/components/PropertiesSection.tsx
+++ b/components/PropertiesSection.tsx
@@ -68,6 +68,7 @@ export default function PropertiesSection({ properties }: PropertiesSectionProps
                     src={property.image}
                     alt={`${property.name} - ${property.description}`}
                     fill
+                    sizes="(max-width: 768px) 80vw, 320px"
                     className="object-cover group-hover:scale-110 transition-transform duration-500"
                   />
                   <div className="absolute top-4 left-4 bg-white/90 backdrop-blur-sm rounded-full px-3 py-1 text-xs font-semibold text-forest">


### PR DESCRIPTION
## Summary
- add an explicit full-width `sizes` hint to the hero background image
- declare breakpoint-aware `sizes` on property card images to improve responsiveness

## Testing
- npm run lint
- Manual: Playwright viewport check for 1280px and 375px


------
https://chatgpt.com/codex/tasks/task_e_68c8d3973458832c9bb1e4aa014257a8