### PR TITLE
Memoize handlers in header and properties sections

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export interface NavItem {
   href: string;
@@ -14,13 +14,13 @@ interface HeaderProps {
 export default function Header({ navItems }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-  const toggleMobileMenu = () => {
+  const toggleMobileMenu = useCallback(() => {
     setIsMobileMenuOpen((previous) => !previous);
-  };
+  }, [setIsMobileMenuOpen]);
 
-  const handleNavigation = () => {
+  const handleNavigation = useCallback(() => {
     setIsMobileMenuOpen(false);
-  };
+  }, [setIsMobileMenuOpen]);
 
   return (
     <header className="fixed top-0 inset-x-0 z-50 bg-cream/90 backdrop-blur border-b border-sand">

--- a/components/PropertiesSection.tsx
+++ b/components/PropertiesSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 export interface PropertyItem {
   id: string;
@@ -21,9 +21,12 @@ interface PropertiesSectionProps {
 export default function PropertiesSection({ properties }: PropertiesSectionProps) {
   const carouselRef = useRef<HTMLDivElement>(null);
 
-  const scrollCarousel = (offset: number) => {
-    carouselRef.current?.scrollBy({ left: offset, behavior: 'smooth' });
-  };
+  const scrollCarousel = useCallback(
+    (offset: number) => {
+      carouselRef.current?.scrollBy({ left: offset, behavior: 'smooth' });
+    },
+    [carouselRef],
+  );
 
   return (
     <section id="properties" className="bg-sand py-20">


### PR DESCRIPTION
## Summary
- memoize the header's menu toggle and navigation handlers with useCallback
- memoize the properties carousel scroll handler for stable references

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8d3995be4832c8875d6545ec63cb1