### PR TITLE
Rebalance hero layout for easier merging

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -80,7 +80,8 @@ function validateSchema<T extends Record<string, unknown>>(
 
   (Object.keys(schema) as Array<keyof T>).forEach(key => {
     const definition = schema[key];
-    const { value, issues = [] } = definition.sanitize(data[key]);
+    const rawValue = data[key as string];
+    const { value, issues = [] } = definition.sanitize(rawValue);
     const validators = definition.validators ?? [];
     const errors: string[] = [...issues];
 

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -14,7 +14,7 @@ export default function Button({ href, children, variant = 'primary', className 
   const styles =
     variant === 'primary'
       ? 'bg-gradient-to-r from-forest to-forest-light text-white hover:from-forest-light hover:to-lake hover:shadow-glow'
-      : 'border-2 border-forest text-forest hover:bg-forest hover:text-white hover:shadow-medium';
+      : 'border-2 border-forest bg-transparent text-forest hover:border-transparent hover:bg-gradient-to-r hover:from-forest hover:to-lake hover:text-white hover:shadow-glow';
   return (
     <Link href={href} className={`${base} ${styles} ${className}`}>
       {children}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,7 +38,7 @@ export default function Header({ navItems }: HeaderProps) {
           ))}
         </ul>
         <button
-          className="md:hidden text-forest"
+          className="md:hidden text-forest text-3xl leading-none p-2 rounded-md border border-forest/20 shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-forest/40"
           aria-label="Menu"
           aria-expanded={isMobileMenuOpen}
           aria-controls="mobile-menu"

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,80 +1,119 @@
+import { Fragment } from 'react';
 import Image from 'next/image';
 import Button from './Button';
 
+const credibilityHighlights = [
+  { icon: '⭐', label: 'Superhost' },
+  { icon: '🕒', label: 'Avg response: < 1 hour' },
+  { icon: '📍', label: 'Western WA' },
+] as const;
+
+const serviceHighlights = [
+  {
+    icon: '🌲',
+    title: 'Local care',
+    description: 'Neighborhood insights and thoughtful touches that feel authentically PNW.',
+  },
+  {
+    icon: '🤝',
+    title: 'Full-service hosting',
+    description: 'Guest messaging, turnovers, and vendor coordination handled start to finish.',
+  },
+  {
+    icon: '📈',
+    title: 'Performance clarity',
+    description: 'Transparent pricing, monthly reporting, and payouts you can plan around.',
+  },
+] as const;
+
 export default function HeroSection() {
   return (
-    <section className="relative min-h-screen flex items-center justify-center text-center text-white overflow-hidden">
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden text-white">
       <div className="absolute inset-0">
         <Image
-          src="https://images.unsplash.com/photo-1506905925346-14b4e5b4e4c3?auto=format&fit=crop&w=1920&q=80"
-          alt="Pacific Northwest mountain landscape"
+          src="https://images.unsplash.com/photo-1461966114269-a79de365c5d8?auto=format&fit=crop&w=1920&q=80"
+          alt="Warm Pacific Northwest Airbnb living room with firelit hospitality touches"
           fill
           sizes="100vw"
-          className="object-cover scale-105"
+          className="object-cover"
           priority
         />
-        <div className="absolute inset-0 bg-gradient-to-br from-forest-dark/80 via-forest/60 to-lake-dark/70" />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-tr from-forest/70 via-forest/40 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-transparent" aria-hidden="true" />
       </div>
 
-      <div className="absolute top-20 left-10 w-20 h-20 bg-accent/20 rounded-full blur-xl animate-pulse" />
-      <div className="absolute bottom-32 right-16 w-32 h-32 bg-lake/20 rounded-full blur-2xl animate-pulse delay-1000" />
-      <div className="absolute top-1/3 right-1/4 w-16 h-16 bg-moss/30 rounded-full blur-lg animate-pulse delay-500" />
+      <div
+        className="absolute left-8 top-24 h-20 w-20 rounded-full bg-lake/20 blur-2xl md:left-16 md:top-28 md:h-24 md:w-24"
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-36 right-10 h-28 w-28 rounded-full bg-forest/25 blur-3xl md:bottom-40 md:right-16 md:h-32 md:w-32"
+        aria-hidden="true"
+      />
+      <div
+        className="absolute right-1/4 top-1/3 h-16 w-16 rounded-full bg-cream/20 blur-lg md:h-20 md:w-20"
+        aria-hidden="true"
+      />
 
-      <div className="relative z-10 max-w-4xl mx-auto p-6">
-        <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full px-4 py-2 mb-8">
-          <span className="w-2 h-2 bg-accent rounded-full animate-pulse" />
-          <span className="text-sm font-medium">Superhost • Under 1hr Response</span>
+      <div className="relative z-10 mx-auto max-w-4xl px-6 py-24 text-center sm:px-8 md:py-32">
+        <div className="mb-6 flex justify-center">
+          <ul className="inline-flex flex-wrap items-center gap-2 rounded-full border border-white/20 bg-white/10 px-6 py-2 text-sm font-medium backdrop-blur-sm">
+            {credibilityHighlights.map(({ icon, label }, index) => (
+              <Fragment key={label}>
+                <li className="flex items-center gap-2 whitespace-nowrap">
+                  <span aria-hidden="true">{icon}</span>
+                  <span>{label}</span>
+                </li>
+                {index < credibilityHighlights.length - 1 && (
+                  <li aria-hidden="true" className="px-1 text-white/60">
+                    •
+                  </li>
+                )}
+              </Fragment>
+            ))}
+          </ul>
         </div>
 
-        <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold leading-tight mb-6">
-          <span className="block bg-gradient-to-r from-white via-cream to-accent-light bg-clip-text text-transparent">
-            Boutique
-          </span>
-          <span className="block bg-gradient-to-r from-accent-light via-white to-lake-light bg-clip-text text-transparent">
-            Airbnb Management
+        <h1 className="text-balance text-4xl font-semibold leading-tight sm:text-5xl md:text-6xl lg:text-7xl">
+          <span className="bg-gradient-to-r from-forest-light via-white to-lake bg-clip-text text-transparent drop-shadow">
+            Boutique Airbnb care rooted in warm Pacific Northwest hospitality.
           </span>
         </h1>
 
-        <p className="text-xl md:text-2xl text-slate-light mb-4 max-w-2xl mx-auto leading-relaxed">
-          That feels <span className="text-accent font-semibold">hands-off</span> and pays off
+        <p className="mt-6 text-lg text-white/85 sm:text-xl">
+          Thoughtful guest experiences, local expertise, and steady returns for Western Washington homeowners who
+          want a trusted partner.
         </p>
-        <p className="text-lg text-slate-light/80 mb-12">Serving Western Washington</p>
+        <p className="mt-2 text-sm uppercase tracking-[0.25em] text-white/70">Serving Western Washington</p>
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-          <Button href="#contact" variant="primary" className="text-lg px-8 py-4 shadow-glow hover:shadow-glow">
+        <div className="mt-12 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          <Button href="#contact" variant="primary" className="px-8 py-4 text-lg shadow-glow">
             Get a Free Property Review
           </Button>
-          <Button
-            href="#how"
-            variant="secondary"
-            className="text-lg px-8 py-4 border-2 border-white/30 hover:border-white/50 hover:bg-white/10"
-          >
+          <Button href="#how" variant="secondary" className="px-8 py-4 text-lg">
             See How It Works
           </Button>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-3xl mx-auto">
-          {[
-            { title: 'Superhost Status', description: 'Consistently maintained', icon: '⭐' },
-            { title: 'Under 1 Hour', description: 'Average response time', icon: '⚡' },
-            { title: 'Western WA', description: 'Local expertise', icon: '📍' },
-          ].map((item) => (
+        <div className="mt-16 grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
+          {serviceHighlights.map((item) => (
             <div
               key={item.title}
-              className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-4 hover:bg-white/15 transition-all duration-300"
+              className="rounded-2xl border border-white/15 bg-white/10 p-6 shadow-soft backdrop-blur-sm transition-transform duration-300 hover:-translate-y-1 hover:bg-white/15"
             >
-              <div className="text-2xl mb-2">{item.icon}</div>
-              <div className="font-semibold text-sm">{item.title}</div>
-              <div className="text-xs text-slate-light">{item.description}</div>
+              <div className="mb-3 text-2xl" aria-hidden="true">
+                {item.icon}
+              </div>
+              <p className="mb-1 text-base font-semibold text-white">{item.title}</p>
+              <p className="text-sm text-white/80">{item.description}</p>
             </div>
           ))}
         </div>
       </div>
 
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <div className="w-6 h-10 border-2 border-white/50 rounded-full flex justify-center">
-          <div className="w-1 h-3 bg-white/70 rounded-full mt-2 animate-pulse" />
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce">
+        <div className="flex h-10 w-6 items-start justify-center rounded-full border-2 border-white/50">
+          <div className="mt-2 h-3 w-1 rounded-full bg-white/70" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- align the hero section structure with the main branch while keeping the warm PNW hospitality styling and soft gradient photo backdrop
- center the expanded credibility pill beside the headline and refresh supporting copy for Western Washington homeowners
- retain the coordinated CTA hover behavior and service highlight cards to minimize future merge conflicts

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8dac262c4832cbb1efbc2310332e6