### PR TITLE
Align AboutSection with new value pillar content structure

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import LocationsSection from '@/components/LocationsSection';
 import ServicesSection from '@/components/ServicesSection';
 import SiteFooter from '@/components/SiteFooter';
 
+import type { AboutSectionProps } from '@/components/AboutSection';
+
 import type { PropertyItem } from '@/components/PropertiesSection';
 
 function SectionHeadingSkeleton({ align = 'center' }: { align?: 'left' | 'center' }) {
@@ -234,27 +236,41 @@ const properties: PropertyItem[] = [
   },
 ];
 
-const features = [
-  { title: 'Faster Responses', description: '24/7 guest messaging under one hour.' },
-  { title: 'Optimized Pricing', description: 'Dynamic rates tuned to demand.' },
-  { title: 'Quality Control', description: 'Checklists and photo proof for every turnover.' },
-];
-
-const timeComparisons = [
-  { label: 'Owner-managed', value: '~25h', barClassName: 'bg-forest' },
-  { label: 'With Julia', value: '~2h', barClassName: 'bg-lake' },
-];
-
-const quickStats = ['🕒 Late-night calls: 4–6 → 0', '💬 Guest messages: handled', '🧹 Turnovers: managed'];
-
-const comparisonTable = [
-  { label: 'Guest Messaging', ownerManaged: 'Delayed', withJulia: '24/7 <1 hr' },
-  { label: 'Pricing', ownerManaged: 'Static', withJulia: 'Dynamic' },
-  { label: 'Guidebook', ownerManaged: 'None', withJulia: 'Touch Stay add-on' },
-  { label: 'Cleaning QC', ownerManaged: 'Inconsistent', withJulia: 'Checklists + photo proof' },
-  { label: 'Reviews/Ranking', ownerManaged: 'Hit-or-miss', withJulia: 'Superhost focus' },
-  { label: 'Reporting', ownerManaged: 'Ad-hoc', withJulia: 'Monthly summaries' },
-];
+const aboutSectionContent: AboutSectionProps = {
+  valuePillars: [
+    { title: 'Faster Responses', description: '24/7 guest messaging under one hour.' },
+    { title: 'Optimized Pricing', description: 'Dynamic rates tuned to demand.' },
+    { title: 'Quality Control', description: 'Checklists and photo proof for every turnover.' },
+  ],
+  timeSavings: [
+    {
+      task: 'Weekly owner hours',
+      ownerManaged: '20–25 hours coordinating stays',
+      withJulia: '~2 hours reviewing payouts',
+      description: 'Dynamic pricing, messaging, and vendor logistics are handled so you only approve key decisions.',
+    },
+    {
+      task: 'Guest communications',
+      ownerManaged: 'Late-night texts and weekend interruptions',
+      withJulia: 'Inbox handled 24/7',
+      description: 'Guests receive under-an-hour replies without you needing to watch your phone.',
+    },
+    {
+      task: 'Turnovers & restocks',
+      ownerManaged: 'Self-managed schedules and supply runs',
+      withJulia: 'QC + photo proof every stay',
+      description: 'Julia books cleaners, verifies standards, and keeps essentials stocked for you.',
+    },
+  ],
+  comparisonRows: [
+    { label: 'Guest Messaging', ownerManaged: 'Delayed', withJulia: '24/7 < 1 hr' },
+    { label: 'Pricing', ownerManaged: 'Static', withJulia: 'Dynamic revenue management' },
+    { label: 'Guidebook', ownerManaged: 'None', withJulia: 'Touch Stay digital guide' },
+    { label: 'Cleaning QC', ownerManaged: 'Inconsistent', withJulia: 'Checklists + photo proof' },
+    { label: 'Reviews/Ranking', ownerManaged: 'Hit-or-miss', withJulia: 'Superhost focus + follow-ups' },
+    { label: 'Reporting', ownerManaged: 'Ad-hoc', withJulia: 'Monthly summaries' },
+  ],
+};
 
 const testimonials = [
   {
@@ -275,12 +291,7 @@ export default function Home() {
         <ServicesSection services={services} />
         <LocationsSection locations={locations} />
         <PropertiesSection properties={properties} />
-        <AboutSection
-          features={features}
-          timeComparisons={timeComparisons}
-          quickStats={quickStats}
-          comparisonTable={comparisonTable}
-        />
+        <AboutSection {...aboutSectionContent} />
         <TestimonialsSection testimonials={testimonials} />
         <ContactSection />
       </main>

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,81 +1,97 @@
-interface FeatureItem {
+export interface ValuePillar {
   title: string;
   description: string;
 }
 
-interface TimeComparison {
-  label: string;
-  value: string;
-  barClassName: string;
+export interface TimeSaving {
+  task: string;
+  ownerManaged: string;
+  withJulia: string;
+  description: string;
 }
 
-interface ComparisonRow {
+export interface ComparisonRow {
   label: string;
   ownerManaged: string;
   withJulia: string;
 }
 
-interface AboutSectionProps {
-  features: FeatureItem[];
-  timeComparisons: TimeComparison[];
-  quickStats: string[];
-  comparisonTable: ComparisonRow[];
+export interface AboutSectionProps {
+  valuePillars: ValuePillar[];
+  timeSavings: TimeSaving[];
+  comparisonRows: ComparisonRow[];
 }
 
 export default function AboutSection({
-  features,
-  timeComparisons,
-  quickStats,
-  comparisonTable,
+  valuePillars,
+  timeSavings,
+  comparisonRows,
 }: AboutSectionProps) {
   return (
     <section id="about" className="py-20">
-      <div className="max-w-6xl mx-auto px-4 space-y-10">
-        <h2 className="text-3xl font-bold text-forest text-center">Why Work With Julia</h2>
+      <div className="mx-auto max-w-6xl space-y-12 px-4">
+        <div className="space-y-4 text-center">
+          <h2 className="text-3xl font-bold text-forest">Why Work With Julia</h2>
+          <p className="mx-auto max-w-3xl text-lg text-slate">
+            Boutique, hands-on management that protects your revenue and gives you back your time.
+          </p>
+        </div>
         <div className="grid gap-8 md:grid-cols-3">
-          {features.map((feature) => (
-            <div key={feature.title}>
-              <h3 className="font-semibold mb-2">{feature.title}</h3>
-              <p className="text-slate">{feature.description}</p>
+          {valuePillars.map((pillar) => (
+            <div key={pillar.title} className="rounded-2xl border border-sand bg-white p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-forest">{pillar.title}</h3>
+              <p className="mt-2 text-sm text-slate">{pillar.description}</p>
             </div>
           ))}
         </div>
-        <div>
-          <h3 className="font-semibold text-center">Time &amp; Stress Savings</h3>
-          <div className="mt-4 space-y-2">
-            {timeComparisons.map((comparison) => (
-              <div key={comparison.label} className="flex items-center">
-                <span className="w-40">{comparison.label}</span>
-                <div className={`flex-1 h-4 ${comparison.barClassName}`} />
-                <span className="ml-2">{comparison.value}</span>
-              </div>
-            ))}
-          </div>
-          <div className="mt-6 grid gap-4 md:grid-cols-3 text-center">
-            {quickStats.map((stat) => (
-              <div key={stat}>{stat}</div>
-            ))}
-          </div>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-sand">
-              <tr>
-                <th className="p-2"></th>
-                <th className="p-2">Owner-Managed</th>
-                <th className="p-2">With Julia</th>
-              </tr>
-            </thead>
-            <tbody>
-              {comparisonTable.map((row) => (
-                <tr key={row.label} className="border-t">
-                  <td className="p-2">{row.label}</td>
-                  <td className="p-2">{row.ownerManaged}</td>
-                  <td className="p-2">{row.withJulia}</td>
-                </tr>
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+          <div className="space-y-6 rounded-3xl border border-sand bg-white p-8 shadow-sm">
+            <div>
+              <h3 className="text-xl font-semibold text-forest">Time Julia Gives Back</h3>
+              <p className="mt-2 text-sm text-slate">
+                Owners typically claw back whole evenings and weekends once Julia owns the day-to-day.
+              </p>
+            </div>
+            <ul className="space-y-5">
+              {timeSavings.map((item) => (
+                <li key={item.task} className="space-y-2">
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <span className="text-base font-medium text-forest">{item.task}</span>
+                    <span className="rounded-full bg-lake/10 px-3 py-1 text-sm font-semibold text-lake">
+                      {item.withJulia}
+                    </span>
+                  </div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate/80">
+                    Owner-managed: {item.ownerManaged}
+                  </div>
+                  <p className="text-sm text-slate">{item.description}</p>
+                </li>
               ))}
-            </tbody>
-          </table>
+            </ul>
+          </div>
+          <div className="overflow-hidden rounded-3xl border border-sand bg-white shadow-sm">
+            <div className="border-b border-sand bg-sand/60 px-6 py-4">
+              <h3 className="text-lg font-semibold text-forest">What Julia Manages For You</h3>
+            </div>
+            <table className="w-full text-left text-sm text-slate">
+              <thead className="bg-sand/40 text-xs uppercase tracking-wide text-forest/80">
+                <tr>
+                  <th className="px-6 py-3">Area</th>
+                  <th className="px-6 py-3">Owner-Managed</th>
+                  <th className="px-6 py-3">With Julia</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonRows.map((row) => (
+                  <tr key={row.label} className="border-t border-sand/70">
+                    <td className="px-6 py-4 font-medium text-forest">{row.label}</td>
+                    <td className="px-6 py-4 align-top">{row.ownerManaged}</td>
+                    <td className="px-6 py-4 align-top text-forest">{row.withJulia}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the AboutSection props with the new valuePillars/timeSavings/comparisonRows shape and refresh the layout to match
- update the home page to construct the aboutSectionContent object that satisfies the updated props and pass it to the section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e491da0e34832caa1f7fc1bb66be73